### PR TITLE
feat(): [#RDV-26] retrieve additional infos for users I can communicate with

### DIFF
--- a/backend/src/main/java/fr/openent/appointments/controller/CommunicationController.java
+++ b/backend/src/main/java/fr/openent/appointments/controller/CommunicationController.java
@@ -74,9 +74,7 @@ public class CommunicationController extends BaseController {
 
         UserUtils.getAuthenticatedUserInfos(eb, request)
             .compose(user -> communicationService.getUsersICanCommunicateWith(user.getUserId(), search, page, limit))
-            .onSuccess(listUserAppointmentResponse -> {
-                renderJson(request, IModelHelper.toJsonArray(listUserAppointmentResponse));
-            })
+            .onSuccess(listUserAppointmentResponse -> renderJson(request, IModelHelper.toJsonArray(listUserAppointmentResponse)))
             .onFailure(err -> {
                 String errorMessage = "Failed to retrieve users I can communicate with";
                 LogHelper.logError(this, "getUsersICanCommunicateWith", errorMessage, err.getMessage());

--- a/backend/src/main/java/fr/openent/appointments/core/constants/Constants.java
+++ b/backend/src/main/java/fr/openent/appointments/core/constants/Constants.java
@@ -3,6 +3,7 @@ package fr.openent.appointments.core.constants;
 public class Constants {
     // camelCase constants
     public static final String CAMEL_ACTOR_ID = "actorId";
+    public static final String CAMEL_AVAILABLE_GRIDS_IDS = "availableGridsIds";
     public static final String CAMEL_BEGIN_DATE = "beginDate";
     public static final String CAMEL_BEGIN_TIME = "beginTime";
     public static final String CAMEL_CREATION_DATE = "creationDate";

--- a/backend/src/main/java/fr/openent/appointments/enums/AppointmentState.java
+++ b/backend/src/main/java/fr/openent/appointments/enums/AppointmentState.java
@@ -1,0 +1,27 @@
+package fr.openent.appointments.enums;
+
+import java.util.Arrays;
+
+public enum AppointmentState {
+    CREATED("CREATED"),
+    ACCEPTED("ACCEPTED"),
+    REFUSED("REFUSED"),
+    CANCELED("CANCELED");
+
+    private final String value;
+
+    AppointmentState(String value) {
+        this.value = value;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public static AppointmentState getAppointmentState(String value) {
+        return Arrays.stream(AppointmentState.values())
+                .filter(appointmentState -> appointmentState.getValue().equals(value))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/backend/src/main/java/fr/openent/appointments/helper/DateHelper.java
+++ b/backend/src/main/java/fr/openent/appointments/helper/DateHelper.java
@@ -13,6 +13,7 @@ public class DateHelper {
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
     private static final DateTimeFormatter TIME_FORMATTER_2 = DateTimeFormatter.ofPattern("HH:mm:ss");
     private static final DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+    private static final DateTimeFormatter DB_DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS");
 
     // Date
 
@@ -66,8 +67,13 @@ public class DateHelper {
         }
         try {
             return LocalDateTime.parse(dateTime, DATE_TIME_FORMATTER);
-        } catch (DateTimeParseException e) {
-            return null;
+        } catch (DateTimeParseException e1) {
+
+            try {
+                return LocalDateTime.parse(dateTime, DB_DATE_TIME_FORMATTER);
+            } catch (DateTimeParseException e2) {
+                return null;
+            }
         }
     }
 

--- a/backend/src/main/java/fr/openent/appointments/helper/LogHelper.java
+++ b/backend/src/main/java/fr/openent/appointments/helper/LogHelper.java
@@ -34,6 +34,6 @@ public class LogHelper {
 
     public static void logInfo(Object classObject, String methodName, String message) {
         Class<?> myClass = classObject.getClass();
-        getLogger(myClass).info(String.format("%s : %s", getBaseLog(myClass, methodName), message));
+        getLogger(myClass).info(String.format("%s %s", getBaseLog(myClass, methodName), message));
     }
 }

--- a/backend/src/main/java/fr/openent/appointments/model/UserAppointment.java
+++ b/backend/src/main/java/fr/openent/appointments/model/UserAppointment.java
@@ -18,13 +18,13 @@ public class UserAppointment implements IModel<UserAppointment> {
 
     // Constructor
 
-    public UserAppointment(NeoUser user) {
+    public UserAppointment(NeoUser user, LocalDate lastAppointmentDate, Boolean availability) {
         this.setUserId(user.getId());
         this.setDisplayName(user.getDisplayName());
         this.setPicture(user.getPicture());
         this.setFunctions(user.getFunctions());
-//        this.setLastAppointmentDate(someInfo);
-//        this.setIsAvailable(someInfo);
+        this.setLastAppointmentDate(lastAppointmentDate);
+        this.setIsAvailable(availability);
     }
 
     // Getter

--- a/backend/src/main/java/fr/openent/appointments/model/database/Appointment.java
+++ b/backend/src/main/java/fr/openent/appointments/model/database/Appointment.java
@@ -1,0 +1,71 @@
+package fr.openent.appointments.model.database;
+
+import fr.openent.appointments.enums.AppointmentState;
+import fr.openent.appointments.helper.IModelHelper;
+import fr.openent.appointments.model.IModel;
+import io.vertx.core.json.JsonObject;
+
+import static fr.openent.appointments.core.constants.Fields.*;
+
+public class Appointment implements IModel<Appointment> {
+
+    private Long id;
+    private Long timeSlotId;
+    private String requesterId;
+    private AppointmentState state;
+
+    // Constructor
+
+    public Appointment(JsonObject appointment) {
+        this.id = appointment.getLong(ID, null);
+        this.timeSlotId = appointment.getLong(TIME_SLOT_ID, null);
+        this.requesterId = appointment.getString(GRID_ID, null);
+        this.state = AppointmentState.getAppointmentState(appointment.getString(STATE, null));
+    }
+
+    // Getter
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getTimeSlotId() {
+        return timeSlotId;
+    }
+
+    public String getRequesterId() {
+        return requesterId;
+    }
+
+    public AppointmentState getState() {
+        return state;
+    }
+
+    // Setter
+
+    public Appointment setId(Long id) {
+        this.id = id;
+        return this;
+    }
+
+    public Appointment setTimeSlotId(Long timeSlotId) {
+        this.timeSlotId = timeSlotId;
+        return this;
+    }
+
+    public Appointment setRequesterId(String requesterId) {
+        this.requesterId = requesterId;
+        return this;
+    }
+
+    public Appointment setState(AppointmentState state) {
+        this.state = state;
+        return this;
+    }
+
+    // Functions
+
+    public JsonObject toJson() {
+        return IModelHelper.toJson(this, true, false);
+    }
+}

--- a/backend/src/main/java/fr/openent/appointments/model/database/NeoUser.java
+++ b/backend/src/main/java/fr/openent/appointments/model/database/NeoUser.java
@@ -19,23 +19,14 @@ public class NeoUser implements IModel<NeoUser> {
     private String displayName;
     private List<String> functions;
     private String picture;
-    private LocalDate lastAppointmentDate;
-    private Boolean isAvailable;
 
     // Constructor
 
     public NeoUser(JsonObject neoUser) {
-        this.setId(neoUser.getString(ID));
-        this.setDisplayName(neoUser.getString(CAMEL_DISPLAY_NAME));
-        this.setFunctions(neoUser.getJsonArray(FUNCTIONS));
-        this.setPicture(neoUser.getString(PICTURE));
-    }
-
-    public NeoUser(JsonObject neoUser, LocalDate lastAppointmentDate, Boolean isAvailable) {
-        this(neoUser);
-        this.setLastAppointmentDate(lastAppointmentDate);
-        this.setIsAvailable(isAvailable);
-
+        this.setId(neoUser.getString(ID, null));
+        this.setDisplayName(neoUser.getString(CAMEL_DISPLAY_NAME, null));
+        this.setFunctions(neoUser.getJsonArray(FUNCTIONS, new JsonArray()));
+        this.setPicture(neoUser.getString(PICTURE, null));
     }
 
     // Getter
@@ -54,14 +45,6 @@ public class NeoUser implements IModel<NeoUser> {
 
     public String getPicture() {
         return picture;
-    }
-
-    public LocalDate getLastAppointmentDate() {
-        return lastAppointmentDate;
-    }
-
-    public Boolean getIsAvailable() {
-        return isAvailable;
     }
 
     // Setter
@@ -87,16 +70,6 @@ public class NeoUser implements IModel<NeoUser> {
 
     public NeoUser setPicture(String picture) {
         this.picture = picture;
-        return this;
-    }
-
-    public NeoUser setLastAppointmentDate(LocalDate lastAppointmentDate) {
-        this.lastAppointmentDate = lastAppointmentDate;
-        return this;
-    }
-
-    public NeoUser setIsAvailable(Boolean isAvailable) {
-        this.isAvailable = isAvailable;
         return this;
     }
 

--- a/backend/src/main/java/fr/openent/appointments/model/database/TimeSlot.java
+++ b/backend/src/main/java/fr/openent/appointments/model/database/TimeSlot.java
@@ -13,21 +13,21 @@ public class TimeSlot implements IModel<TimeSlot> {
 
     private Long id;
     private Long gridId;
-    private LocalDateTime begin;
-    private LocalDateTime end;
+    private LocalDateTime beginDate;
+    private LocalDateTime endDate;
 
     // Constructor
 
     public TimeSlot(JsonObject timeslot) {
         this.id = timeslot.getLong(ID, null);
         this.gridId = timeslot.getLong(GRID_ID, null);
-        this.begin = DateHelper.parseDateTime(timeslot.getString(BEGIN, null));
-        this.end = DateHelper.parseDateTime(timeslot.getString(END, null));
+        this.beginDate = DateHelper.parseDateTime(timeslot.getString(BEGIN_DATE, null));
+        this.endDate = DateHelper.parseDateTime(timeslot.getString(END_DATE, null));
     }
 
     public TimeSlot(LocalDateTime begin, LocalDateTime end) {
-        this.begin = begin;
-        this.end = end;
+        this.beginDate = begin;
+        this.endDate = end;
     }
 
     // Getter
@@ -40,12 +40,12 @@ public class TimeSlot implements IModel<TimeSlot> {
         return gridId;
     }
 
-    public LocalDateTime getBegin() {
-        return begin;
+    public LocalDateTime getBeginDate() {
+        return beginDate;
     }
 
-    public LocalDateTime getEnd() {
-        return end;
+    public LocalDateTime getEndDate() {
+        return endDate;
     }
 
     // Setter
@@ -60,13 +60,13 @@ public class TimeSlot implements IModel<TimeSlot> {
         return this;
     }
 
-    public TimeSlot setBegin(LocalDateTime begin) {
-        this.begin = begin;
+    public TimeSlot setBeginDate(LocalDateTime beginDate) {
+        this.beginDate = beginDate;
         return this;
     }
 
-    public TimeSlot setEnd(LocalDateTime end) {
-        this.end = end;
+    public TimeSlot setEndDate(LocalDateTime endDate) {
+        this.endDate = endDate;
         return this;
     }
 
@@ -76,8 +76,8 @@ public class TimeSlot implements IModel<TimeSlot> {
         return "TimeSlot{" +
                 "id=" + id +
                 ", gridId=" + gridId +
-                ", begin=" + begin +
-                ", end=" + end +
+                ", beginDate=" + beginDate +
+                ", endDate=" + endDate +
                 '}';
     }
 

--- a/backend/src/main/java/fr/openent/appointments/repository/GridRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/GridRepository.java
@@ -35,6 +35,26 @@ public interface GridRepository {
     Future<JsonArray> getMyGridsByName(String userId, String gridName, List<GridState> gridStates);
 
     /**
+     * Retrieves all grids associated to a list of a specific user.
+     *
+     * @param usersIds list of unique identifier of the users whose grids are to be retrieved.
+     * @return a {@link Future} representing the asynchronous operation, which will
+     *         return a {@link List<Grid>} containing the details of the grids associated
+     *         with the specified users.
+     */
+    Future<List<Grid>> getGridsByUserIds(List<String> usersIds);
+
+    /**
+     * Retrieves all the grids from the list with at least one available time slot.
+     *
+     * @param gridsIds List of IDs of the grids to check.
+     * @return a {@link Future} representing the asynchronous operation, which will
+     *         return a {@link List<Grid>} containing the {@link Grid} of the given list
+     *         having at least one available time slot.
+     */
+    Future<List<Grid>> getGridsWithAvailableTimeSlots(List<Long> gridsIds);
+
+    /**
      * Retrieves the name of all grids associated with a specific user.
      *
      * @param userId the unique identifier of the user whose grids are to be retrieved.

--- a/backend/src/main/java/fr/openent/appointments/repository/TimeSlotRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/TimeSlotRepository.java
@@ -3,6 +3,7 @@ package fr.openent.appointments.repository;
 import fr.openent.appointments.model.database.TimeSlot;
 import fr.openent.appointments.model.payload.TimeSlotPayload;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
 
 import java.util.List;
 
@@ -10,9 +11,20 @@ public interface TimeSlotRepository {
     /**
      * Create multiple time slots for a specific grid.
      *
-     * @param timeSlots a {@link List} of {@link TimeSlotPayload} to insert into the database
-     * @return a {@link Future} representing the asynchronous operation, which will
-     *         return a {@link List} of the {@link TimeSlot} created and their details.
+     * @param timeSlots a {@link List<TimeSlotPayload>} to insert into the database
+     * @return A {@link Future} representing the asynchronous operation, which will
+     *         return a {@link List<TimeSlot>} of the created timeslots and their details.
      */
     Future<List<TimeSlot>> create(Long gridId, List<TimeSlotPayload> timeSlots);
+
+    /**
+     * Retrieve connected user's last appointment date for specific grid owners
+     *
+     * @param userId The ID of the connected user
+     * @param ownersIds The IDs of the owners of the grid we are interested in
+     * @return A {@link Future} representing the asynchronous operation, which will
+     *         return a {@link JsonArray} containing for each grid owner id the date of
+     *         last appointment for the connected user.
+     */
+    Future<JsonArray> getLastAppointmentDateByGridOwner(String userId, List<String> ownersIds);
 }

--- a/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultCommunicationRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultCommunicationRepository.java
@@ -17,6 +17,9 @@ import java.util.List;
 
 import static fr.openent.appointments.core.constants.Constants.*;
 
+/**
+ * Default implementation of the CommunicationRepository interface.
+ */
 public class DefaultCommunicationRepository implements CommunicationRepository {
 
     private final Neo4j neo4j;

--- a/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultDailySlotRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultDailySlotRepository.java
@@ -20,6 +20,9 @@ import java.util.List;
 import static fr.openent.appointments.core.constants.Fields.*;
 import static fr.openent.appointments.core.constants.SqlTables.DB_DAILY_SLOT_TABLE;
 
+/**
+ * Default implementation of the DailySlotRepository interface.
+ */
 public class DefaultDailySlotRepository implements DailySlotRepository {
 
     private final Sql sql;

--- a/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultTimeSlotRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultTimeSlotRepository.java
@@ -1,6 +1,9 @@
 package fr.openent.appointments.repository.impl;
 
+import fr.openent.appointments.enums.AppointmentState;
+import fr.openent.appointments.enums.GridState;
 import fr.openent.appointments.helper.DateHelper;
+import fr.openent.appointments.helper.FutureHelper;
 import fr.openent.appointments.helper.IModelHelper;
 import fr.openent.appointments.helper.TransactionHelper;
 import fr.openent.appointments.model.TransactionElement;
@@ -12,6 +15,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import org.entcore.common.sql.Sql;
+import org.entcore.common.sql.SqlResult;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -20,6 +24,9 @@ import java.util.List;
 import static fr.openent.appointments.core.constants.Fields.*;
 import static fr.openent.appointments.core.constants.SqlTables.*;
 
+/**
+ * Default implementation of the TimeSlotRepository interface.
+ */
 public class DefaultTimeSlotRepository implements TimeSlotRepository {
 
     private final Sql sql;
@@ -55,6 +62,46 @@ public class DefaultTimeSlotRepository implements TimeSlotRepository {
         TransactionHelper.executeTransactionAndGetJsonObjectResults(transactionElements, errorMessage)
             .onSuccess(result -> promise.complete(IModelHelper.toList(result, TimeSlot.class)))
             .onFailure(promise::fail);
+
+        return promise.future();
+    }
+
+    @Override
+    public Future<JsonArray> getLastAppointmentDateByGridOwner(String userId, List<String> ownersIds) {
+        Promise<JsonArray> promise = Promise.promise();
+
+        if (ownersIds == null || ownersIds.isEmpty()) {
+            promise.complete(new JsonArray());
+            return promise.future();
+        }
+
+        String query =
+                // First we rank every timeslot (by owner) matching our filtering
+                "WITH ranked_timeslots AS ( " +
+                    "SELECT ts.end_date, g.owner_id, ROW_NUMBER() OVER (PARTITION BY g.owner_id ORDER BY ts.end_date DESC) AS row_num " +
+                    "FROM " + DB_TIME_SLOT_TABLE + " ts " +
+                    "JOIN " + DB_GRID_TABLE + " g ON ts.grid_id = g.id " +
+                    "JOIN " + DB_APPOINTMENT_TABLE + " a ON a.time_slot_id = ts.id " +
+                    "WHERE g.owner_id IN " + Sql.listPrepared(ownersIds) +
+                    "AND g.state = ? " +
+                    "AND a.state = ? " +
+                    "AND a.requester_id = ? " +
+                    "AND ts.end_date < NOW() " +
+                ") " +
+                // Then we just pick the first ranked lines (ie the later appointment dates for each owner)
+                "SELECT " + END_DATE + ", " + OWNER_ID + " FROM ranked_timeslots " +
+                "WHERE row_num = 1" +
+                "ORDER BY " + END_DATE + " DESC;";
+
+        JsonArray params = new JsonArray()
+                .addAll(ownersIds.stream().collect(JsonArray::new, JsonArray::add, JsonArray::addAll))
+                .add(GridState.OPEN)
+                .add(AppointmentState.ACCEPTED)
+                .add(userId);
+
+        String errorMessage = "[Appointments@DefaultTimeSlotRepository::getLastAppointmentDateByGridOwner] Fail to get last appointment date for grid owners : " + ownersIds;
+        sql.prepared(query, params, SqlResult.validResultHandler(FutureHelper.handlerEither(promise, errorMessage)));
+
 
         return promise.future();
     }

--- a/backend/src/main/java/fr/openent/appointments/service/GridService.java
+++ b/backend/src/main/java/fr/openent/appointments/service/GridService.java
@@ -10,6 +10,7 @@ import io.vertx.core.http.HttpServerRequest;
 import fr.openent.appointments.model.payload.GridPayload;
 
 import java.util.List;
+import java.util.Map;
 
 /**
  * Interface for managing grid operations in the appointment service.
@@ -54,10 +55,19 @@ public interface GridService {
     Future<JsonArray> getUserGrids(Integer userId);
 
     /**
+     * Count the number of available timeslots for the specified grids.
+     *
+     * @param gridsIds A {@link List<Long>} of grid ids for which we count the available timeslots.
+     * @return A {@link Future} representing the asynchronous operation, which will
+     *         return a {@link List<Long>} containing ths IDs of the grids having a timeslot available.
+     */
+    Future<List<Long>> getGridsIdsWithAvailableTimeSlots(List<Long> gridsIds);
+
+    /**
      * Creates a new grid.
      *
      * @param grid A JsonArray containing the data of the grid to be created.
-     * @return A Future containing {@Link Grid} that will complete when the grid has been created.
+     * @return A Future containing {@link Grid} that will complete when the grid has been created.
      */
     Future<Grid> createGrid(HttpServerRequest request, GridPayload grid);
 

--- a/backend/src/main/java/fr/openent/appointments/service/ServiceFactory.java
+++ b/backend/src/main/java/fr/openent/appointments/service/ServiceFactory.java
@@ -1,6 +1,8 @@
 package fr.openent.appointments.service;
 
 import fr.openent.appointments.config.AppConfig;
+import fr.openent.appointments.repository.TimeSlotRepository;
+import fr.openent.appointments.service.impl.DefaultTimeSlotService;
 import io.vertx.core.Vertx;
 import io.vertx.core.eventbus.EventBus;
 
@@ -12,14 +14,16 @@ public class ServiceFactory {
 
     private final Vertx vertx;
     private final AppConfig appConfig;
+    private final TimeSlotService timeSlotService;
     private final GridService gridService;
     private final CommunicationService communicationService;
 
     public ServiceFactory(Vertx vertx, AppConfig appConfig, RepositoryFactory repositoryFactory) {
         this.vertx = vertx;
         this.appConfig = appConfig;
+        this.timeSlotService = new DefaultTimeSlotService(this, repositoryFactory);
         this.gridService = new DefaultGridService(this, repositoryFactory);
-        this.communicationService = new DefaultCommunicationService(repositoryFactory);
+        this.communicationService = new DefaultCommunicationService(this, repositoryFactory);
     }
 
     public Vertx vertx() {
@@ -32,6 +36,10 @@ public class ServiceFactory {
 
     public AppConfig appConfig() {
         return this.appConfig;
+    }
+
+    public TimeSlotService timeSlotService() {
+        return this.timeSlotService;
     }
 
     public GridService gridService() {

--- a/backend/src/main/java/fr/openent/appointments/service/TimeSlotService.java
+++ b/backend/src/main/java/fr/openent/appointments/service/TimeSlotService.java
@@ -1,0 +1,26 @@
+package fr.openent.appointments.service;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Interface for managing grid operations in the appointment service.
+ */
+public interface TimeSlotService {
+
+    /**
+     * Retrieves all minimized grids associated with the current user.
+     *
+     * @param userId The ID of the connected user
+     * @param ownersIds The IDs of the owners of the grid we are interested in
+     * @return A {@link Future} representing the asynchronous operation, which will
+     *         return a {@link Map}<{@link String},{@link LocalDate}> containing for each grid owner id the date of
+     *         last appointment for the connected user.
+     */
+    Future<Map<String,LocalDate>> getLastAppointmentDateByGridOwner(String userId, List<String> ownersIds);
+
+}

--- a/backend/src/main/java/fr/openent/appointments/service/impl/DefaultCommunicationService.java
+++ b/backend/src/main/java/fr/openent/appointments/service/impl/DefaultCommunicationService.java
@@ -2,25 +2,45 @@ package fr.openent.appointments.service.impl;
 
 import fr.openent.appointments.helper.LogHelper;
 import fr.openent.appointments.model.UserAppointment;
+import fr.openent.appointments.model.database.Grid;
 import fr.openent.appointments.model.database.NeoGroup;
 import fr.openent.appointments.model.database.NeoUser;
+import fr.openent.appointments.repository.GridRepository;
 import fr.openent.appointments.service.CommunicationService;
 import fr.openent.appointments.repository.CommunicationRepository;
 import fr.openent.appointments.repository.RepositoryFactory;
+import fr.openent.appointments.service.GridService;
+import fr.openent.appointments.service.ServiceFactory;
+import fr.openent.appointments.service.TimeSlotService;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
+import static fr.openent.appointments.core.constants.Constants.CAMEL_AVAILABLE_GRIDS_IDS;
 import static fr.openent.appointments.core.constants.Constants.STRUCTURES;
 
+/**
+ * Default implementation of the CommunicationService interface.
+ */
 public class DefaultCommunicationService implements CommunicationService {
+    private final TimeSlotService timeSlotService;
+    private final GridService gridService;
     private final CommunicationRepository communicationRepository;
+    private final GridRepository gridRepository;
 
-    public DefaultCommunicationService(RepositoryFactory repositoryFactory) {
+    public DefaultCommunicationService(ServiceFactory serviceFactory, RepositoryFactory repositoryFactory) {
+        this.timeSlotService = serviceFactory.timeSlotService();
+        this.gridService = serviceFactory.gridService();
         this.communicationRepository = repositoryFactory.communicationRepository();
+        this.gridRepository = repositoryFactory.gridRepository();
     }
 
 
@@ -43,18 +63,18 @@ public class DefaultCommunicationService implements CommunicationService {
     public Future<List<UserAppointment>> getUsersICanCommunicateWith(String userId, String search, Long page, Long limit) {
         Promise<List<UserAppointment>> promise = Promise.promise();
 
-
         communicationRepository.getGroupsICanCommunicateWith(userId)
             .compose(groups -> {
                 List<String> groupsIds = groups.stream()
                         .map(NeoGroup::getId)
                         .collect(Collectors.toList());
-                return this.getUsersFromGroupsIds(userId, groupsIds);
+                return getUsersFromGroupsIds(userId, groupsIds);
             })
-            .onSuccess(users -> {
+            .compose(users -> {
                 List<NeoUser> filteredUsers = filterNeoUsersBySearchAndPagination(users, search, page, limit);
-                promise.complete(buildListUserAppointementResponse(filteredUsers));
+                return getGridsAndBuildListUserAppointementResponse(userId, filteredUsers);
             })
+            .onSuccess(promise::complete)
             .onFailure(err -> {
                 String errorMessage = "Failed to retrieve users I can communicate with";
                 LogHelper.logError(this, "getUsersICanCommunicateWith", errorMessage, err.getMessage());
@@ -110,9 +130,68 @@ public class DefaultCommunicationService implements CommunicationService {
         return filteredUsers;
     }
 
-    private List<UserAppointment> buildListUserAppointementResponse(List<NeoUser> users) {
-        return users.stream()
-            .map(UserAppointment::new)
-            .collect(Collectors.toList());
+    private Future<List<UserAppointment>> getGridsAndBuildListUserAppointementResponse(String userId, List<NeoUser> users) {
+        Promise<List<UserAppointment>> promise = Promise.promise();
+
+        List<String> usersIds = users.stream().map(NeoUser::getId).collect(Collectors.toList());
+        gridRepository.getGridsByUserIds(usersIds)
+            .compose(grids -> getAdditionalInfosAndBuildListUserAppointementResponse(userId, grids, users))
+            .onSuccess(promise::complete)
+            .onFailure(err -> {
+                String errorMessage = "Failed to retrieve grids associated with users ids " + usersIds;
+                LogHelper.logError(this, "getGridsAndBuildListUserAppointementResponse", errorMessage, err.getMessage());
+                promise.fail(err);
+            });
+
+        return promise.future();
+    }
+
+    private Future<List<UserAppointment>> getAdditionalInfosAndBuildListUserAppointementResponse(String userId, List<Grid> grids, List<NeoUser> users) {
+        Promise<List<UserAppointment>> promise = Promise.promise();
+        JsonObject composeInfos = new JsonObject();
+
+        List<Long> gridsIds = grids.stream().map(Grid::getId).collect(Collectors.toList());
+        gridService.getGridsIdsWithAvailableTimeSlots(gridsIds)
+            .compose(availableGridsIds -> {
+                composeInfos.put(CAMEL_AVAILABLE_GRIDS_IDS, availableGridsIds);
+                List<String> ownersIds = users.stream().map(NeoUser::getId).collect(Collectors.toList());
+                return timeSlotService.getLastAppointmentDateByGridOwner(userId, ownersIds);
+            })
+            .onSuccess(ownerIdsLastDateMap -> {
+                Map<NeoUser, LocalDate> usersMap = new HashMap<>();
+                users.forEach(user -> {
+                    LocalDate lastAppointmentDate = ownerIdsLastDateMap.getOrDefault(user.getId(), null);
+                    usersMap.put(user, lastAppointmentDate);
+                });
+
+                List<Long> availabilities = composeInfos.getJsonArray(CAMEL_AVAILABLE_GRIDS_IDS).stream()
+                        .filter(Long.class::isInstance)
+                        .map(Long.class::cast)
+                        .collect(Collectors.toList());
+
+                promise.complete(buildListUserAppointementResponse(usersMap, grids, availabilities));
+            })
+            .onFailure(err -> {
+                String errorMessage = "Failed get additional infos to build UserAppointment";
+                LogHelper.logError(this, "getAdditionalInfosAndBuildListUserAppointementResponse", errorMessage, err.getMessage());
+                promise.fail(err);
+            });
+
+        return promise.future();
+    }
+
+    private List<UserAppointment> buildListUserAppointementResponse(Map<NeoUser,LocalDate> users, List<Grid> grids, List<Long> availableGridsIds) {
+        List<UserAppointment> listUserAppointementResponse = new ArrayList<>();
+
+        users.forEach((user, lastAppointmentDate) -> {
+                List<Long> userGridIds = grids.stream()
+                        .filter(grid -> grid.getOwnerId().equals(user.getId()))
+                        .map(Grid::getId)
+                        .collect(Collectors.toList());
+                boolean availability = availableGridsIds.stream().anyMatch(userGridIds::contains);
+                listUserAppointementResponse.add(new UserAppointment(user, lastAppointmentDate, availability));
+            });
+
+        return listUserAppointementResponse;
     }
 }

--- a/backend/src/main/java/fr/openent/appointments/service/impl/DefaultGridService.java
+++ b/backend/src/main/java/fr/openent/appointments/service/impl/DefaultGridService.java
@@ -24,8 +24,6 @@ import java.util.stream.Collectors;
 
 import org.entcore.common.user.UserUtils;
 
-import static fr.openent.appointments.core.constants.Constants.CAMEL_GRID_ID;
-
 /**
  * Default implementation of the GridService interface.
  */
@@ -76,6 +74,21 @@ public class DefaultGridService implements GridService {
     public Future<JsonArray> getUserGrids(Integer userId) {
         // TODO: Implement the logic to retrieve all grids associated with a specific user.
         return Future.succeededFuture(new JsonArray());
+    }
+
+    @Override
+    public Future<List<Long>> getGridsIdsWithAvailableTimeSlots(List<Long> gridsIds) {
+        Promise<List<Long>> promise = Promise.promise();
+
+        gridRepository.getGridsWithAvailableTimeSlots(gridsIds)
+            .onSuccess(grids -> promise.complete(grids.stream().map(Grid::getId).distinct().collect(Collectors.toList())))
+            .onFailure(err -> {
+                String errorMessage = "Failed to get grids with available timeslots from grid ids " + gridsIds;
+                LogHelper.logError(this, "getGridsIdsWithAvailableTimeSlots", errorMessage, err.getMessage());
+                promise.fail(err);
+            });
+
+        return promise.future();
     }
 
     private Future<Boolean> isGridAlreadyExists(String gridName, String userId) {
@@ -157,7 +170,6 @@ public class DefaultGridService implements GridService {
                 .limit(limit)
                 .collect(Collectors.toList());
         }
-
 
         return new ListGridsResponse((long) grids.size(), paginatedGrids);
     }

--- a/backend/src/main/java/fr/openent/appointments/service/impl/DefaultTimeSlotService.java
+++ b/backend/src/main/java/fr/openent/appointments/service/impl/DefaultTimeSlotService.java
@@ -1,0 +1,59 @@
+package fr.openent.appointments.service.impl;
+
+import fr.openent.appointments.helper.DateHelper;
+import fr.openent.appointments.helper.LogHelper;
+import fr.openent.appointments.repository.RepositoryFactory;
+import fr.openent.appointments.repository.TimeSlotRepository;
+import fr.openent.appointments.service.TimeSlotService;
+import fr.openent.appointments.service.ServiceFactory;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static fr.openent.appointments.core.constants.Fields.END_DATE;
+import static fr.openent.appointments.core.constants.Fields.OWNER_ID;
+
+/**
+ * Default implementation of the TimeSlotService interface.
+ */
+public class DefaultTimeSlotService implements TimeSlotService {
+    private final TimeSlotRepository timeSlotRepository;
+
+    public DefaultTimeSlotService(ServiceFactory serviceFactory, RepositoryFactory repositoryFactory) {
+        this.timeSlotRepository = repositoryFactory.timeSlotRepository();
+    }
+
+    @Override
+    public Future<Map<String, LocalDate>> getLastAppointmentDateByGridOwner(String userId, List<String> ownersIds) {
+        Promise<Map<String, LocalDate>> promise = Promise.promise();
+
+        timeSlotRepository.getLastAppointmentDateByGridOwner(userId, ownersIds)
+            .onSuccess(lastDatesByOwnerId -> {
+                Map<String, LocalDate> mapOwnerIdLastAppointmentDate = new HashMap<>();
+                ownersIds.forEach(ownerId -> {
+                    LocalDate lastAppointmentDate = lastDatesByOwnerId.stream()
+                            .filter(JsonObject.class::isInstance)
+                            .map(JsonObject.class::cast)
+                            .filter(lastDateByOwnerId -> lastDateByOwnerId.getString(OWNER_ID).equals(ownerId))
+                            .findFirst()
+                            .map(lastDateByOwnerId -> DateHelper.parseDateTime(lastDateByOwnerId.getString(END_DATE, null)).toLocalDate())
+                            .orElse(null);
+                    mapOwnerIdLastAppointmentDate.put(ownerId, lastAppointmentDate);
+                });
+
+                promise.complete(mapOwnerIdLastAppointmentDate);
+            })
+            .onFailure(err -> {
+                String errorMessage = "Failed to retrieve last appointment date for ownersIds " + ownersIds;
+                LogHelper.logError(this, "getLastAppointmentDateByGridOwner", errorMessage, err.getMessage());
+                promise.fail(err.getMessage());
+            });
+
+        return promise.future();
+    }
+}


### PR DESCRIPTION
## Describe your changes
Follow https://github.com/OPEN-ENT-NG/appointments/pull/11

Here we retrieve more informations bout the grids creator the connected user can see.
We added two pieces of informations :
- if a grid owner at least has one available timeslot in the futur (availability)
- the date of the last appointment with the conneted user if there was one (lastAppointmentDate)

## Checklist tests

## Issue ticket number and link

RDV-26 : https://jira.support-ent.fr/browse/RDV-26

## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)