### PR TITLE
fix: #RDV-59 some fix from RC

### DIFF
--- a/backend/src/main/resources/view-src/notify/update_grid_notification.html
+++ b/backend/src/main/resources/view-src/notify/update_grid_notification.html
@@ -10,7 +10,8 @@
   {{#appointmentUri}}
   <a href="{{#host}}{{appointmentUri}}{{/host}}">
     {{#i18n}}appointments{{/i18n}}</a
-  >. {{/appointmentUri}} {{^appointmentUri}} {{#i18n}}appointments{{/i18n}}.
+  >
+  {{/appointmentUri}} {{^appointmentUri}} {{#i18n}}appointments{{/i18n}}.
   {{/appointmentUri}}
   {{#i18n}}timeline.appointments.update.grid.to.know.more{{/i18n}}
 </span>

--- a/frontend/src/containers/BookAppointmentGridInfos/index.tsx
+++ b/frontend/src/containers/BookAppointmentGridInfos/index.tsx
@@ -23,7 +23,6 @@ import { UserPicture } from "~/components/UserPicture";
 import { APPOINTMENTS, DURATION_VALUES } from "~/core/constants";
 import { DURATION } from "~/core/enums";
 import { useBookAppointmentModal } from "~/providers/BookAppointmentModalProvider";
-import { ellipsisWithWrapStyle } from "~/styles/textStyles";
 import {
   bottomUserInfoStyle,
   itemStyle,
@@ -140,14 +139,16 @@ export const BookAppointmentGridInfos: FC<BookAppointmentGridInfosProps> = ({
             <Box sx={itemStyle}>
               <ChatIcon />
               <Stack maxWidth="90%">
-                <Typography
-                  variant="body2"
-                  color="text.primary"
-                  sx={ellipsisWithWrapStyle}
-                  fontStyle="italic"
+                <EllipsisWithTooltip
+                  typographyProps={{
+                    variant: "body2",
+                    color: "text.primary",
+                    fontStyle: "italic",
+                    whiteSpace: "pre-line",
+                  }}
                 >
                   {publicComment}
-                </Typography>
+                </EllipsisWithTooltip>
               </Stack>
             </Box>
           )}

--- a/frontend/src/containers/FirstPageGridModal/index.tsx
+++ b/frontend/src/containers/FirstPageGridModal/index.tsx
@@ -20,7 +20,6 @@ import {
   ALLOWED_DOCUMENT_EXTENSIONS,
   APPOINTMENTS,
   MAX_FILE_PER_GRID,
-  MAX_STRING_LENGTH,
   MAX_TOTAL_FILE_SIZE_PER_GRID_MO,
 } from "~/core/constants";
 import { useGlobal } from "~/providers/GlobalProvider";
@@ -68,6 +67,7 @@ export const FirstPageGridModal: FC = () => {
     totalFilesSize,
     handleAddFile,
     handleDeleteFile,
+    isPublicCommentOverLimit,
   } = useGridModal();
 
   const isAddDocumentDisabled = useMemo(
@@ -168,10 +168,9 @@ export const FirstPageGridModal: FC = () => {
         value={inputs.publicComment}
         onChange={handlePublicCommentChange}
         helperText={
-          inputs.publicComment.length === MAX_STRING_LENGTH &&
-          t("appointments.grid.comment.text.helper")
+          isPublicCommentOverLimit && t("appointments.grid.comment.text.helper")
         }
-        error={inputs.publicComment.length === MAX_STRING_LENGTH}
+        error={isPublicCommentOverLimit}
         disabled={modalType === GRID_MODAL_TYPE.CONSULTATION}
       />
       <Box sx={documentBoxStyle}>

--- a/frontend/src/hooks/types.ts
+++ b/frontend/src/hooks/types.ts
@@ -49,6 +49,7 @@ export interface useUpdateGridInputsReturnType {
 
 export type useUpdateGridInputsType = (
   inputs: GridModalInputs,
+  setIsPublicCommentOverLimit: Dispatch<SetStateAction<boolean>>,
   setInputs: Dispatch<SetStateAction<GridModalInputs>>,
   setErrorInputs: Dispatch<SetStateAction<InputsErrors>>,
   structureOptions: Structure[],

--- a/frontend/src/hooks/useUpdateGridInputs/index.ts
+++ b/frontend/src/hooks/useUpdateGridInputs/index.ts
@@ -12,6 +12,7 @@ import dayjs, { Dayjs } from "dayjs";
 import { v4 as uuidv4 } from "uuid";
 
 import { HexaColor } from "~/components/ColorPicker/types";
+import { MAX_STRING_LENGTH } from "~/core/constants";
 import { DAY, DURATION, PERIODICITY } from "~/core/enums";
 import {
   FIELD_REQUIRED_ERROR,
@@ -34,6 +35,7 @@ import { formatString, handleConflictingSlot } from "./utils";
 
 export const useUpdateGridInputs: useUpdateGridInputsType = (
   inputs: GridModalInputs,
+  setIsPublicCommentOverLimit: Dispatch<SetStateAction<boolean>>,
   setInputs: Dispatch<SetStateAction<GridModalInputs>>,
   setErrorInputs: Dispatch<SetStateAction<InputsErrors>>,
   structureOptions: Structure[],
@@ -108,6 +110,7 @@ export const useUpdateGridInputs: useUpdateGridInputsType = (
   };
 
   const handlePublicCommentChange = (e: ChangeEvent<HTMLInputElement>) => {
+    setIsPublicCommentOverLimit(e.target.value.length > MAX_STRING_LENGTH);
     updateInputField("publicComment", formatString(e.target.value));
   };
 

--- a/frontend/src/providers/GridModalProvider/index.tsx
+++ b/frontend/src/providers/GridModalProvider/index.tsx
@@ -100,6 +100,9 @@ export const GridModalProvider: FC<GridModalProviderProps> = ({ children }) => {
   const [errorInputs, setErrorInputs] =
     useState<InputsErrors>(initialErrorInputs);
 
+  const [isPublicCommentOverLimit, setIsPublicCommentOverLimit] =
+    useState<boolean>(false);
+
   useEffect(() => {
     if (structures.length)
       setInputs((prev) => ({
@@ -120,6 +123,7 @@ export const GridModalProvider: FC<GridModalProviderProps> = ({ children }) => {
   const updateGridModalInputs: useUpdateGridInputsReturnType =
     useUpdateGridInputs(
       inputs,
+      setIsPublicCommentOverLimit,
       setInputs,
       setErrorInputs,
       structures,
@@ -138,6 +142,7 @@ export const GridModalProvider: FC<GridModalProviderProps> = ({ children }) => {
   }, [blurGridModalInputs]);
 
   const resetInputs = useCallback(() => {
+    setIsPublicCommentOverLimit(false);
     setInputs(initialGridModalInputs(structures));
     setErrorInputs(initialErrorInputs);
   }, [structures]);
@@ -333,6 +338,7 @@ export const GridModalProvider: FC<GridModalProviderProps> = ({ children }) => {
       handleDeleteFile,
       initFiles,
       isSubmitButtonLoading,
+      isPublicCommentOverLimit,
     }),
     [
       inputs,
@@ -361,6 +367,7 @@ export const GridModalProvider: FC<GridModalProviderProps> = ({ children }) => {
       handleDeleteFile,
       initFiles,
       isSubmitButtonLoading,
+      isPublicCommentOverLimit,
     ],
   );
 

--- a/frontend/src/providers/GridModalProvider/types.ts
+++ b/frontend/src/providers/GridModalProvider/types.ts
@@ -53,6 +53,7 @@ export interface GridModalProviderContextProps {
   handleDeleteFile: (file: MyCustomFile) => void;
   initFiles: (documents: Document[], modalType: GRID_MODAL_TYPE) => void;
   isSubmitButtonLoading: boolean;
+  isPublicCommentOverLimit: boolean;
 }
 
 export interface GridModalProviderProps {


### PR DESCRIPTION
## Describe your changes

This pull request includes multiple changes across various files to improve the handling of public comments in the grid modal and update the notification HTML template. The most important changes are grouped by theme below:

### Public Comment Handling Enhancements:

* [`frontend/src/hooks/useUpdateGridInputs/index.ts`](diffhunk://#diff-196647edf6b5c599da19eae198e0a3e650ad35baf5126aeda5ea9b1624cc3f9dR15): Added logic to check if the public comment exceeds the maximum string length and set the `isPublicCommentOverLimit` state accordingly. [[1]](diffhunk://#diff-196647edf6b5c599da19eae198e0a3e650ad35baf5126aeda5ea9b1624cc3f9dR15) [[2]](diffhunk://#diff-196647edf6b5c599da19eae198e0a3e650ad35baf5126aeda5ea9b1624cc3f9dR38) [[3]](diffhunk://#diff-196647edf6b5c599da19eae198e0a3e650ad35baf5126aeda5ea9b1624cc3f9dR113)
* [`frontend/src/providers/GridModalProvider/index.tsx`](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR103-R105): Introduced the `isPublicCommentOverLimit` state and passed it to the `useUpdateGridInputs` hook. Also, reset this state when the inputs are reset. [[1]](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR103-R105) [[2]](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR126) [[3]](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR145) [[4]](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR341) [[5]](diffhunk://#diff-292c93739b1ac72d5ae7210c7b41a6b5aadd69042c582351da81b7a333d4cc5fR370)
* [`frontend/src/containers/FirstPageGridModal/index.tsx`](diffhunk://#diff-22823bb3a5e1648f6a8f4d81631e6f656f47f5611292047ea5c38478223fb9c4R70): Updated the helper text and error handling for the public comment input field to use the new `isPublicCommentOverLimit` state. [[1]](diffhunk://#diff-22823bb3a5e1648f6a8f4d81631e6f656f47f5611292047ea5c38478223fb9c4R70) [[2]](diffhunk://#diff-22823bb3a5e1648f6a8f4d81631e6f656f47f5611292047ea5c38478223fb9c4L171-R173)

### Notification HTML Template Update:

* [`backend/src/main/resources/view-src/notify/update_grid_notification.html`](diffhunk://#diff-1b1c305581751ef4f0bc026f3e94d55d8945ff0b837643c05319d8a14fbffca0L13-R14): Fixed the formatting issue in the notification HTML template for appointment links.

### Code Cleanup:

* [`frontend/src/containers/BookAppointmentGridInfos/index.tsx`](diffhunk://#diff-30917cd50061b267ecafac44644f230eccf9cc486aec27e1bd30d09287f4f144L26): Removed the unused `ellipsisWithWrapStyle` import and replaced the `Typography` component with the `EllipsisWithTooltip` component for better text handling. [[1]](diffhunk://#diff-30917cd50061b267ecafac44644f230eccf9cc486aec27e1bd30d09287f4f144L26) [[2]](diffhunk://#diff-30917cd50061b267ecafac44644f230eccf9cc486aec27e1bd30d09287f4f144L143-R151)
* [`frontend/src/containers/FirstPageGridModal/index.tsx`](diffhunk://#diff-22823bb3a5e1648f6a8f4d81631e6f656f47f5611292047ea5c38478223fb9c4L23): Removed the unused `MAX_STRING_LENGTH` import.

These changes enhance the user experience by improving the handling of public comments and fixing formatting issues in notifications.

## Checklist tests

## Issue ticket number and link

[RDV-59](https://jira.support-ent.fr/browse/RDV-59)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)