### PR TITLE
feat: restrict search to 3 characters for ADML users

### DIFF
--- a/frontend/src/containers/FindAppointments/index.tsx
+++ b/frontend/src/containers/FindAppointments/index.tsx
@@ -5,7 +5,10 @@ import { useTranslation } from "react-i18next";
 
 import { FindAppointmentsEmptyState } from "~/components/SVG/FindAppointmentsEmptyState";
 import { UserCard } from "~/components/UserCard";
-import { APPOINTMENTS } from "~/core/constants";
+import {
+  APPOINTMENTS,
+  MIN_NB_CHAR_BEFORE_SEARCH_FOR_ADML,
+} from "~/core/constants";
 import { useBookAppointmentModal } from "~/providers/BookAppointmentModalProvider";
 import { useFindAppointments } from "~/providers/FindAppointmentsProvider";
 import { useGlobal } from "~/providers/GlobalProvider";
@@ -76,7 +79,9 @@ export const FindAppointments: FC = () => {
         {!users.length && !isFetching && (
           <Box sx={emptyStateBoxStyle}>
             <Typography variant="body1" sx={emptyStateTextStyle}>
-              {!search || (isConnectedUserADML && search.length < 3)
+              {!search ||
+              (isConnectedUserADML &&
+                search.length < MIN_NB_CHAR_BEFORE_SEARCH_FOR_ADML)
                 ? t("appointments.find.empty.state.search.bar")
                 : t("appointments.find.empty.state.no.user")}
             </Typography>

--- a/frontend/src/containers/FindAppointments/index.tsx
+++ b/frontend/src/containers/FindAppointments/index.tsx
@@ -8,6 +8,7 @@ import { UserCard } from "~/components/UserCard";
 import { APPOINTMENTS } from "~/core/constants";
 import { useBookAppointmentModal } from "~/providers/BookAppointmentModalProvider";
 import { useFindAppointments } from "~/providers/FindAppointmentsProvider";
+import { useGlobal } from "~/providers/GlobalProvider";
 import { BookAppointmentModal } from "../BookAppointmentModal";
 import {
   containerStyle,
@@ -31,6 +32,7 @@ export const FindAppointments: FC = () => {
   const { t } = useTranslation(APPOINTMENTS);
   const observerRef = useRef<IntersectionObserver | null>(null);
   const targetRef = useRef<HTMLDivElement | null>(null);
+  const { isConnectedUserADML } = useGlobal();
 
   const handleObserver = useCallback(
     (entries: IntersectionObserverEntry[]) => {
@@ -74,7 +76,7 @@ export const FindAppointments: FC = () => {
         {!users.length && !isFetching && (
           <Box sx={emptyStateBoxStyle}>
             <Typography variant="body1" sx={emptyStateTextStyle}>
-              {!search
+              {!search || (isConnectedUserADML && search.length < 3)
                 ? t("appointments.find.empty.state.search.bar")
                 : t("appointments.find.empty.state.no.user")}
             </Typography>

--- a/frontend/src/core/constants.ts
+++ b/frontend/src/core/constants.ts
@@ -29,6 +29,8 @@ export const MAX_TOTAL_FILE_SIZE_PER_GRID_MO = 100; // Mo
 export const MAX_TOTAL_FILE_SIZE_PER_GRID_O =
   MAX_TOTAL_FILE_SIZE_PER_GRID_MO * 1024 * 1024;
 
+export const MIN_NB_CHAR_BEFORE_SEARCH_FOR_ADML = 3;
+
 export const ALLOWED_DOCUMENT_EXTENSIONS = [
   ".pdf",
   ".csv",

--- a/frontend/src/providers/FindAppointmentsProvider/index.tsx
+++ b/frontend/src/providers/FindAppointmentsProvider/index.tsx
@@ -10,6 +10,7 @@ import {
 
 import { useGetCommunicationUsersQuery } from "~/services/api/CommunicationService";
 import { UserCardInfos } from "~/services/api/CommunicationService/types";
+import { useGlobal } from "../GlobalProvider";
 import {
   FindAppointmentsProviderContextProps,
   FindAppointmentsProviderProps,
@@ -34,6 +35,7 @@ export const FindAppointmentsProvider: FC<FindAppointmentsProviderProps> = ({
 }) => {
   const [users, setUsers] = useState<UserCardInfos[]>([]);
   const [page, setPage] = useState(1);
+  const { isConnectedUserADML } = useGlobal();
   const [search, setSearch] = useState("");
   const [hasMoreUsers, setHasMoreUsers] = useState(true);
   const {
@@ -46,7 +48,7 @@ export const FindAppointmentsProvider: FC<FindAppointmentsProviderProps> = ({
       page,
       limit: NUMBER_MORE_USERS,
     },
-    { skip: !search },
+    { skip: !search || (isConnectedUserADML && search.length < 3) },
   );
 
   useEffect(() => {

--- a/frontend/src/providers/FindAppointmentsProvider/index.tsx
+++ b/frontend/src/providers/FindAppointmentsProvider/index.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 
+import { MIN_NB_CHAR_BEFORE_SEARCH_FOR_ADML } from "~/core/constants";
 import { useGetCommunicationUsersQuery } from "~/services/api/CommunicationService";
 import { UserCardInfos } from "~/services/api/CommunicationService/types";
 import { useGlobal } from "../GlobalProvider";
@@ -48,7 +49,12 @@ export const FindAppointmentsProvider: FC<FindAppointmentsProviderProps> = ({
       page,
       limit: NUMBER_MORE_USERS,
     },
-    { skip: !search || (isConnectedUserADML && search.length < 3) },
+    {
+      skip:
+        !search ||
+        (isConnectedUserADML &&
+          search.length < MIN_NB_CHAR_BEFORE_SEARCH_FOR_ADML),
+    },
   );
 
   useEffect(() => {

--- a/frontend/src/providers/GlobalProvider/index.tsx
+++ b/frontend/src/providers/GlobalProvider/index.tsx
@@ -9,6 +9,7 @@ import {
 
 import { isActionAvailable } from "@edifice.io/client";
 
+import { useUser } from "@edifice.io/react";
 import { useTranslation } from "react-i18next";
 import { APPOINTMENTS } from "~/core/constants";
 import { useStructure } from "~/hooks/useStructure";
@@ -50,6 +51,9 @@ export const GlobalProvider: FC<GlobalProviderProps> = ({
     initialDisplayModalsState,
   );
 
+  const { user } = useUser();
+  const isConnectedUserADML = !!user?.functions?.ADMIN_LOCAL;
+
   const handleDisplayModal = (modalType: MODAL_TYPE) => {
     setDisplayModals((prevState) => ({
       ...prevState,
@@ -80,6 +84,7 @@ export const GlobalProvider: FC<GlobalProviderProps> = ({
       setDisplayModals,
       handleDisplayModal,
       minHoursBeforeCancellation,
+      isConnectedUserADML,
     }),
     [
       isMultiStructure,
@@ -90,6 +95,7 @@ export const GlobalProvider: FC<GlobalProviderProps> = ({
       getStructureNameById,
       displayModals,
       minHoursBeforeCancellation,
+      isConnectedUserADML,
     ],
   );
 

--- a/frontend/src/providers/GlobalProvider/types.ts
+++ b/frontend/src/providers/GlobalProvider/types.ts
@@ -15,6 +15,7 @@ export interface GlobalProviderContextProps {
   setDisplayModals: Dispatch<SetStateAction<DisplayModalsState>>;
   handleDisplayModal: (modalType: MODAL_TYPE) => void;
   minHoursBeforeCancellation: number;
+  isConnectedUserADML: boolean;
 }
 
 export interface GlobalProviderProps {


### PR DESCRIPTION
## Describe your changes

This pull request includes changes to enforce a minimum search query length for ADML users and updates to the `FindAppointmentsProvider` and `GlobalProvider` components to support this new validation. The most important changes include adding the search query length validation in the backend, updating the frontend components to use the new validation logic, and modifying the context provider to include the ADML user check.

Backend validation:

* [`backend/src/main/java/fr/openent/appointments/controller/CommunicationController.java`](diffhunk://#diff-67bf1e0602b40814fd70c4af4a16616d43e362f3b70cc701af3c298d7ec2220fR96-R108): Added a check to ensure that ADML users have a search query of at least 3 characters long. If the condition is not met, an error is logged, a bad request is returned, and the future is failed.

Frontend updates:

* [`frontend/src/providers/FindAppointmentsProvider/index.tsx`](diffhunk://#diff-2068269c6e46b0a8719494b511f0e9574e3817451ae8e4ef076169f30a7501e4R13): Imported `useGlobal` from `GlobalProvider` and added the `isConnectedUserADML` check to skip the query if the search length is less than 3 characters for ADML users. [[1]](diffhunk://#diff-2068269c6e46b0a8719494b511f0e9574e3817451ae8e4ef076169f30a7501e4R13) [[2]](diffhunk://#diff-2068269c6e46b0a8719494b511f0e9574e3817451ae8e4ef076169f30a7501e4R38) [[3]](diffhunk://#diff-2068269c6e46b0a8719494b511f0e9574e3817451ae8e4ef076169f30a7501e4L49-R51)

Context provider modifications:

* [`frontend/src/providers/GlobalProvider/index.tsx`](diffhunk://#diff-fcc32e1ecf6f34ac83355db3b1c83901a6b12b4c9b0df00228ae9251896c2bbbR12): Imported `useUser` to determine if the connected user is an ADML user and added `isConnectedUserADML` to the context provider's value. [[1]](diffhunk://#diff-fcc32e1ecf6f34ac83355db3b1c83901a6b12b4c9b0df00228ae9251896c2bbbR12) [[2]](diffhunk://#diff-fcc32e1ecf6f34ac83355db3b1c83901a6b12b4c9b0df00228ae9251896c2bbbR54-R56) [[3]](diffhunk://#diff-fcc32e1ecf6f34ac83355db3b1c83901a6b12b4c9b0df00228ae9251896c2bbbR87) [[4]](diffhunk://#diff-fcc32e1ecf6f34ac83355db3b1c83901a6b12b4c9b0df00228ae9251896c2bbbR98)
* [`frontend/src/providers/GlobalProvider/types.ts`](diffhunk://#diff-034acfadcbcd9fa294a62f12734a7a8762dba60f2b2e9bb76867d755bef9dc54R18): Updated the `GlobalProviderContextProps` interface to include the `isConnectedUserADML` boolean property.

## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)