### PR TITLE
fix(search): #RDV-69 fix groups communication rules

### DIFF
--- a/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultCommunicationRepository.java
+++ b/backend/src/main/java/fr/openent/appointments/repository/impl/DefaultCommunicationRepository.java
@@ -103,7 +103,6 @@ public class DefaultCommunicationRepository implements CommunicationRepository {
     private String getCommunicationQuery(boolean isIncoming, String structureId) {
         // first part of the query is to get groups that can communicate with me
         // second part is to get groups that can communicate with groups I am in
-        // third part is to get groups I am in
         return "MATCH (g:Group)"+ (isIncoming ? "-[:COMMUNIQUE]-> " : "<-[:COMMUNIQUE]- ")+ "(u:User { id: {userId}}) " +
                 "WHERE exists(g.id) " +
                 "OPTIONAL MATCH (sg:Structure)<-[:DEPENDS]-(g) " +
@@ -119,19 +118,6 @@ public class DefaultCommunicationRepository implements CommunicationRepository {
 
                 "MATCH (u:User {id: {userId}})-[:IN]->(ug:Group) " +
                 "MATCH (g:Group)" + (isIncoming ? "-[:COMMUNIQUE]->(ug) " : "<-[:COMMUNIQUE]-(ug) ")+
-                "WHERE exists(g.id) " +
-                "OPTIONAL MATCH (sg:Structure)<-[:DEPENDS]-(g) " +
-                "OPTIONAL MATCH (sc:Structure)<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(g) " +
-                "WITH COALESCE(sg, sc) as s, c, g " +
-                (structureId != null ? "WHERE s.id = {structureId} " : "") +
-                "WITH s, c, g " +
-                "RETURN DISTINCT " +
-                "   g.id as id, " +
-                "   g.name as name " +
-
-                "UNION " +
-
-                "MATCH (u:User {id: {userId}})-[:IN]->(g:Group) " +
                 "WHERE exists(g.id) " +
                 "OPTIONAL MATCH (sg:Structure)<-[:DEPENDS]-(g) " +
                 "OPTIONAL MATCH (sc:Structure)<-[:BELONGS]-(c:Class)<-[:DEPENDS]-(g) " +


### PR DESCRIPTION
## Describe your changes

This pull request includes changes to the `DefaultCommunicationRepository` class to simplify the `getCommunicationQuery` method by removing redundant query parts.

Codebase simplification:

* [`backend/src/main/java/fr/openent/appointments/repository/impl/DefaultCommunicationRepository.java`](diffhunk://#diff-bfd913f064491b0c2a2b5c30c56632b3f52960dfc752ea24b1997725e41915fcL106): Removed the third part of the query that retrieves groups the user is in, as it was redundant. This change simplifies the query and improves performance. [[1]](diffhunk://#diff-bfd913f064491b0c2a2b5c30c56632b3f52960dfc752ea24b1997725e41915fcL106) [[2]](diffhunk://#diff-bfd913f064491b0c2a2b5c30c56632b3f52960dfc752ea24b1997725e41915fcL130-L142)


[RDV-69](https://jira.support-ent.fr/browse/RDV-69)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)