### PR TITLE
fix(grid): #RDV-68 increase limit target_public_list_id on grid table

### DIFF
--- a/backend/src/main/resources/sql/003-update-tables.sql
+++ b/backend/src/main/resources/sql/003-update-tables.sql
@@ -1,0 +1,1 @@
+ALTER TABLE appointments.grid ALTER COLUMN target_public_list_id TYPE varchar(10000);


### PR DESCRIPTION
## Describe your changes

This pull request includes an important change to the database schema in the `003-update-tables.sql` file. The change alters the column type of `target_public_list_id` in the `appointments.grid` table to `varchar(10000)`.

Database schema update:

* [`backend/src/main/resources/sql/003-update-tables.sql`](diffhunk://#diff-b2909e376f8cee46769dd5ca5469736f32e56892b077b1ab79bd7627f1aa851eR1): Changed the column type of `target_public_list_id` in the `appointments.grid` table to `varchar(10000)`.

## Checklist tests

## Issue ticket number and link

[RDV-68](https://jira.support-ent.fr/browse/RDV-68)

## Checklist before requesting a review (magic string, indentation, comment/documentation...)
- [ ] I have detailed the tests to do in my feature/fix in order to prevent consequents regressions (must specify in **Checklist tests**)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation (API Doc etc...) - (must specify in **Description** for target version)
- [ ] If it is a consequent feature, I have added thorough tests.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been added to this project (must specify in **Description**)